### PR TITLE
fix issue with app root while running tests

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -4,7 +4,7 @@ var os = require('os');
 var df = require('node-df');
 var path = require('path');
 
-var appRootDir = path.dirname(require.main.filename);
+var appRootDir = require('app-root-path'); 
 var pjson = require(appRootDir + path.sep +'package.json');
 
 var DEFAULT_PATH = '/ping';

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/AlexeyKhristov/koa-ping",
   "dependencies": {
-    "node-df": "^0.1.1"
+    "node-df": "^0.1.1",
+    "app-root-path": "^1.0.0"
   }
 }


### PR DESCRIPTION
The current logic for finding appRootDir does not work when run until a build tool (for example gulp), so the unit tests will fail. This is a pretty simple and self explanatory fix for that. If you'd like to see how the logic to resolve app root differs from what you have, see here:

https://www.npmjs.com/package/app-root-path
